### PR TITLE
add(api/feed) caching layer for render speed

### DIFF
--- a/routes/api/feed/index.js
+++ b/routes/api/feed/index.js
@@ -6,14 +6,35 @@
   const request = require('request');
   const RSS_URL = 'https://api.fantasydata.net/nfl/v2/json/News';
 
+  let cache = {};
+
+  // Initiate Api Call
+  getApiReponse();
+
+  // Get new live updates every 6 hours
+  // Limit 1000 uses per API Key
+  setInterval(function() {
+    getApiReponse();
+  }, 21600000);
+
+  // Return cached response
   router.get('/rss', (req, res) => {
+    if (cache) {
+      return res.send(cache);
+    } else {
+      getApiReponse();
+    }
+  });
+
+  // Make Api Call
+  function getApiReponse() {
     request(RSS_URL, {
       headers: { 'Ocp-Apim-Subscription-Key': process.env.FANTASYDATA_API_KEY }
     }, function(err, response) {
-      if (err) { return res.status(400).send(err); }
-      res.send(response.body);
+      if (err) { return console.log(err); }
+      cache = response.body;
     });
-  });
+  }
 
   module.exports = router;
 }());


### PR DESCRIPTION
Summary: Adds caching layer for live fantasy data. Response every six hours to save API limit and super fast render speed !
